### PR TITLE
handle undefined element in closestAll

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import onPaint from 'on-paint';
 
 if (!window.restrictScroll) {
   function closestAll(element, filter = '*', lineage = []) {
+    if (!element) return lineage;
     if (element.matches(filter)) lineage.push(element);
 
     const parent = element.parentElement || element.getRootNode().host;


### PR DESCRIPTION
If restrict-scroll tries to handle a keyboard event after the element has been removed from the document, ActiveElement will return null and cause closestAll to fail. This PR adds an early return to closestAll so that it is resilient to null element arguments. 